### PR TITLE
:rocket: feat(relationship/belongsto): create if not exists

### DIFF
--- a/src/Eloquent/Concerns/HasFillableRelations.php
+++ b/src/Eloquent/Concerns/HasFillableRelations.php
@@ -110,7 +110,7 @@ trait HasFillableRelations
         $entity = $attributes;
         if (!$attributes instanceof Model) {
             $entity = $relation->getRelated()
-                ->where($attributes)->firstOrFail();
+                ->firstOrCreate($attributes);
         }
 
         $relation->associate($entity);


### PR DESCRIPTION
# Description

This PR fix the error `No query results for model` when you try to fill a `belongsTo` relationship with non previously created data.